### PR TITLE
Upgrade ipld-eth-server image and enable statediff support 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
     restart: unless-stopped
     depends_on:
       - migrations
-    image: vulcanize/ipld-eth-server:v4.1.0-alpha
+    image: vulcanize/ipld-eth-server:v4.1.1-alpha
     environment:
       VDB_COMMAND: "serve"
       ETH_SERVER_HTTPPATH: 0.0.0.0:8082


### PR DESCRIPTION
Part of https://github.com/vulcanize/watcher-ts/issues/127

- Upgrade `ipld-eth-server` image to `vulcanize/ipld-eth-server:v4.1.1-alpha`
- Enable statediff support in `ipld-eth-server` service