### PR TITLE
Upgrade Geth to use watched addresses from direct indexing params by default

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=linux/amd64 alpine
 
 WORKDIR /app
 
-RUN wget https://github.com/vulcanize/go-ethereum/releases/download/v1.10.19-statediff-4.1.0-alpha/geth-linux-amd64 && \
+RUN wget https://github.com/vulcanize/go-ethereum/releases/download/v1.10.19-statediff-4.1.1-alpha/geth-linux-amd64 && \
 	mv geth-linux-amd64 geth && \
 	chmod +x geth && \
 	mv geth /usr/local/bin


### PR DESCRIPTION
Part of vulcanize/watcher-ts#127