### PR TITLE
Update eth-statediff-fill-service to latest version

### DIFF
--- a/local/eth-statediff-fill-service/Dockerfile
+++ b/local/eth-statediff-fill-service/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add busybox-extras
 WORKDIR /app
 
 RUN git clone https://github.com/vulcanize/eth-statediff-fill-service.git && \
-	cd eth-statediff-fill-service && git checkout v4.0.4-alpha && \
+	cd eth-statediff-fill-service && git checkout v4.0.5-alpha && \
 	go mod download
 
 # Build the binary


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/160