### PR TITLE
Upgrade postgres version in the watcher db service

### DIFF
--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -113,7 +113,7 @@ services:
 
   watcher-db:
     restart: unless-stopped
-    image: postgres:12-alpine
+    image: postgres:14-alpine
     environment:
       - POSTGRES_USER=vdbm
       - POSTGRES_MULTIPLE_DATABASES=mobymask-watcher,mobymask-watcher-job-queue

--- a/mainnet-watcher-only/docker-compose.yml
+++ b/mainnet-watcher-only/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   watcher-db:
     restart: unless-stopped
-    image: postgres:12-alpine
+    image: postgres:14-alpine
     environment:
       - POSTGRES_USER=vdbm
       - POSTGRES_MULTIPLE_DATABASES=mobymask-watcher,mobymask-watcher-job-queue

--- a/mainnet/docker-compose.yml
+++ b/mainnet/docker-compose.yml
@@ -106,7 +106,7 @@ services:
 
   watcher-db:
     restart: unless-stopped
-    image: postgres:12-alpine
+    image: postgres:14-alpine
     environment:
       - POSTGRES_USER=vdbm
       - POSTGRES_MULTIPLE_DATABASES=mobymask-watcher,mobymask-watcher-job-queue


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/184

- Upgrade docker image for watcher database service from `postgres:12-alpine` to `postgres:14-alpine`