### PR TITLE
Upgrade core and watcher services

### DIFF
--- a/common/watcher-ts/Dockerfile
+++ b/common/watcher-ts/Dockerfile
@@ -9,7 +9,7 @@ RUN echo "git clone https://github.com/vulcanize/assemblyscript.git" && \
 
 RUN echo "git clone https://github.com/cerc-io/watcher-ts.git" && \
     git clone https://github.com/cerc-io/watcher-ts.git /app && \
-    cd app && git checkout v0.2.12 && \
+    cd app && git checkout v0.2.13 && \
     cd packages/graph-node && yarn remove @vulcanize/assemblyscript && \
     yarn add https://github.com/vulcanize/assemblyscript.git#ng-integrate-asyncify && \
     cd /app && yarn && yarn link "@vulcanize/assemblyscript" && yarn build

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     depends_on:
       ipld-eth-db:
         condition: service_healthy
-    image: git.vdb.to/cerc-io/ipld-eth-db:v4.2.1-alpha-unstable
+    image: git.vdb.to/cerc-io/ipld-eth-db/ipld-eth-db:v4.2.1-alpha-unstable
     environment:
       DATABASE_USER: "vdbm"
       DATABASE_NAME: "indexer"
@@ -61,7 +61,7 @@ services:
     restart: unless-stopped
     depends_on:
       - migrations
-    image: gti.vdb.to/cerc-io/ipld-eth-server:v4.1.8-alpha
+    image: git.vdb.to/cerc-io/ipld-eth-server/ipld-eth-server:v4.2.0-alpha
     environment:
       VDB_COMMAND: "serve"
       ETH_CHAIN_CONFIG: "/tmp/chain.json"

--- a/local/eth-statediff-fill-service/Dockerfile
+++ b/local/eth-statediff-fill-service/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add busybox-extras
 WORKDIR /app
 
 RUN git clone https://github.com/vulcanize/eth-statediff-fill-service.git && \
-	cd eth-statediff-fill-service && git checkout v4.0.5-alpha && \
+	cd eth-statediff-fill-service && git checkout v4.0.6-alpha && \
 	go mod download
 
 # Build the binary

--- a/local/geth/Dockerfile
+++ b/local/geth/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=linux/amd64 alpine
 
 WORKDIR /app
 
-RUN wget https://github.com/cerc-io/go-ethereum/releases/download/v1.10.23-statediff-4.2.0-alpha/geth-linux-amd64 && \
+RUN wget https://git.vdb.to/api/packages/cerc-io/generic/go-ethereum/v1.10.25-statediff-4.2.1-alpha/geth-linux-amd64 && \
 	mv geth-linux-amd64 geth && \
 	chmod +x geth && \
 	mv geth /usr/local/bin

--- a/local/watcher-ts/mobymask-watcher.toml
+++ b/local/watcher-ts/mobymask-watcher.toml
@@ -22,6 +22,8 @@
 [metrics]
   host = "0.0.0.0"
   port = 9000
+  [metrics.gql]
+    port = 9001
 
 [database]
   type = "postgres"

--- a/mainnet/docker-compose.yml
+++ b/mainnet/docker-compose.yml
@@ -77,7 +77,7 @@ services:
     restart: unless-stopped
     depends_on:
       - migrations
-    image: cerc-io/ipld-eth-server:v4.1.8-alpha
+    image: git.vdb.to/cerc-io/ipld-eth-server/ipld-eth-server:v4.2.0-alpha
     environment:
       VDB_COMMAND: "serve"
       ETH_SERVER_HTTPPATH: 0.0.0.0:8082

--- a/mainnet/geth/Dockerfile
+++ b/mainnet/geth/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=linux/amd64 alpine
 
 WORKDIR /app
 
-RUN wget https://github.com/cerc-io/go-ethereum/releases/download/v1.10.23-statediff-4.2.0-alpha/geth-linux-amd64 && \
+RUN wget https://git.vdb.to/api/packages/cerc-io/generic/go-ethereum/v1.10.25-statediff-4.2.1-alpha/geth-linux-amd64 && \
 	mv geth-linux-amd64 geth && \
 	chmod +x geth && \
 	mv geth /usr/local/bin

--- a/mainnet/lighthouse/run.sh
+++ b/mainnet/lighthouse/run.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # Start a beacon node.
-
 lighthouse \
 	--debug-level info \
 	--network mainnet \


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/127

Upgrade:
- Core:
  - `ipld-eth-db` to `v4.2.1-alpha-unstable`
  - cerc-io-geth to `v1.10.25-statediff-4.2.1-alpha`
  - `ipld-eth-server` to `v4.2.0-alpha`
  - `eth-statediff-fill-service` to `v4.0.6-alpha`
- Watcher:
  - `watcher-ts` to `v0.2.13`