### PR TITLE
Upgrade core and watcher services

### DIFF
--- a/common/watcher-ts/Dockerfile
+++ b/common/watcher-ts/Dockerfile
@@ -9,7 +9,7 @@ RUN echo "git clone https://github.com/vulcanize/assemblyscript.git" && \
 
 RUN echo "git clone https://github.com/cerc-io/watcher-ts.git" && \
     git clone https://github.com/cerc-io/watcher-ts.git /app && \
-    cd app && git checkout v0.2.13 && \
+    cd app && git checkout v0.2.17 && \
     cd packages/graph-node && yarn remove @vulcanize/assemblyscript && \
     yarn add https://github.com/vulcanize/assemblyscript.git#ng-integrate-asyncify && \
     cd /app && yarn && yarn link "@vulcanize/assemblyscript" && yarn build

--- a/common/watcher-ts/mobymask-watcher.toml
+++ b/common/watcher-ts/mobymask-watcher.toml
@@ -9,8 +9,8 @@
   # Checkpoint interval in number of blocks.
   checkpointInterval = 2000
 
-  # IPFS API address (can be taken from the output on running the IPFS daemon).
-  # ipfsApiAddr = "/ip4/127.0.0.1/tcp/5001"
+  # Enable state creation
+  enableState = true
 
   # Boolean to filter logs by contract.
   filterLogs = true
@@ -39,7 +39,6 @@
   [upstream.ethServer]
     gqlApiEndpoint = "http://ipld-eth-server:8083/graphql"
     rpcProviderEndpoint = "http://ipld-eth-server:8082"
-    blockDelayInMilliSecs = 60000
 
   [upstream.cache]
     name = "requests"
@@ -51,3 +50,6 @@
   maxCompletionLagInSecs = 300
   jobDelayInMilliSecs = 100
   eventsInBatch = 50
+  blockDelayInMilliSecs = 60000
+  prefetchBlocksInMem = true
+  prefetchBlockCount = 10

--- a/local/README.md
+++ b/local/README.md
@@ -1,5 +1,15 @@
 # Local Demo
 
+## Setup
+
+* Create a `watcher.env` file from [watcher.env.sample](./watcher.env.sample) with updated DB credentials:
+
+  ```
+  cp watcher.env.sample watcher.env
+  ```
+
+## Run
+
 * Start the core services:
 
   ```bash
@@ -15,7 +25,7 @@
   # ✅  Published contracts to the subgraph package.
   # Done in 14.28s.
   ```
-  
+
   Export the address of the deployed contract to a shell variable for later use:
 
   ```bash
@@ -32,7 +42,7 @@
   docker-compose exec -w /app/packages/hardhat mobymask yarn claimMember --contract $MOBY_ADDRESS --name oldMember
   ```
 
-* Stop the docker services and reset the indexer database to demonstrate statediffing only for the watched address. The database will later be filled by `eth-statediff-fill-service` with data only for the watched address. 
+* Stop the docker services and reset the indexer database to demonstrate statediffing only for the watched address. The database will later be filled by `eth-statediff-fill-service` with data only for the watched address.
 
   ```bash
   # Stop the docker services
@@ -43,7 +53,7 @@
   docker volume rm local_indexer_db_data
   ```
 
-* Start all the services (core and watcher) now: 
+* Start all the services (core and watcher) now:
 
   ```bash
   docker-compose --profile watcher up --build -d
@@ -84,7 +94,7 @@
   ```
 
   A message for running gap filler should appear at the end. Example:
-  
+
   ```bash
   eth-statediff-fill-service_1    | time="2022-07-05T09:17:59Z" level=info msg="running watched address gap filler for block range: (30, 137)"
   ```
@@ -168,7 +178,7 @@
 * Update contract `isPhisher` and `isMember` maps with new names:
 
   ```bash
-  docker-compose exec -w /app/packages/hardhat mobymask yarn claimPhisher --contract $MOBY_ADDRESS --name newPhisher 
+  docker-compose exec -w /app/packages/hardhat mobymask yarn claimPhisher --contract $MOBY_ADDRESS --name newPhisher
   ```
 
   ```bash
@@ -203,7 +213,7 @@
         data
       }
     }
-    
+
     isMember(
       blockHash: "EVENT_BLOCK_HASH"
       contractAddress: "MOBY_ADDRESS",

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -114,11 +114,7 @@ services:
   watcher-db:
     restart: unless-stopped
     image: postgres:14-alpine
-    environment:
-      - POSTGRES_USER=vdbm
-      - POSTGRES_MULTIPLE_DATABASES=mobymask-watcher,mobymask-watcher-job-queue
-      - POSTGRES_EXTENSION=mobymask-watcher-job-queue:pgcrypto
-      - POSTGRES_PASSWORD=password
+    env_file: ./watcher.env
     volumes:
       - ../common/initdb.d/multiple-postgressql-databases.sh:/docker-entrypoint-initdb.d/multiple-postgressql-databases.sh
       - watcher_db_data:/var/lib/postgresql/data

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     depends_on:
       ipld-eth-db:
         condition: service_healthy
-    image: git.vdb.to/cerc-io/ipld-eth-db/ipld-eth-db:v4.2.1-alpha-unstable
+    image: git.vdb.to/cerc-io/ipld-eth-db/ipld-eth-db:v4.2.3-alpha
     environment:
       DATABASE_USER: "vdbm"
       DATABASE_NAME: "indexer"
@@ -61,7 +61,7 @@ services:
     restart: unless-stopped
     depends_on:
       - migrations
-    image: git.vdb.to/cerc-io/ipld-eth-server/ipld-eth-server:v4.2.0-alpha
+    image: git.vdb.to/cerc-io/ipld-eth-server/ipld-eth-server:v4.2.3-alpha
     environment:
       VDB_COMMAND: "serve"
       ETH_CHAIN_CONFIG: "/tmp/chain.json"
@@ -139,9 +139,11 @@ services:
         condition: service_healthy
       watcher-db:
         condition: service_healthy
+      mobymask-watcher-job-runner:
+        condition: service_healthy
     build:
       context: ../common/watcher-ts
-    command: ["sh", "-c", "yarn server"]
+    command: ["node", "--enable-source-maps", "dist/server.js"]
     volumes:
       - ./watcher-ts/mobymask-watcher.toml:/app/packages/mobymask-watcher/environments/local.toml
     ports:
@@ -160,18 +162,22 @@ services:
     depends_on:
       ipld-eth-server:
         condition: service_healthy
-      mobymask-watcher-server:
-        condition: service_healthy
       watcher-db:
         condition: service_healthy
     build:
       context: ../common/watcher-ts
-    command: ["sh", "-c", "yarn job-runner"]
+    command: ["node", "--enable-source-maps", "dist/job-runner.js"]
     volumes:
       - ./watcher-ts/mobymask-watcher.toml:/app/packages/mobymask-watcher/environments/local.toml
     profiles: ["watcher"]
     ports:
       - "0.0.0.0:9000:9000"
+    healthcheck:
+      test: ["CMD", "nc", "-v", "localhost", "9000"]
+      interval: 20s
+      timeout: 5s
+      retries: 15
+      start_period: 5s
 
   mobymask:
     restart: unless-stopped

--- a/local/eth-statediff-fill-service/Dockerfile
+++ b/local/eth-statediff-fill-service/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add busybox-extras
 WORKDIR /app
 
 RUN git clone https://github.com/vulcanize/eth-statediff-fill-service.git && \
-	cd eth-statediff-fill-service && git checkout v4.0.6-alpha && \
+	cd eth-statediff-fill-service && git checkout v4.0.7-alpha && \
 	go mod download
 
 # Build the binary

--- a/local/geth/Dockerfile
+++ b/local/geth/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=linux/amd64 alpine
 
 WORKDIR /app
 
-RUN wget https://git.vdb.to/api/packages/cerc-io/generic/go-ethereum/v1.10.25-statediff-4.2.1-alpha/geth-linux-amd64 && \
+RUN wget https://git.vdb.to/api/packages/cerc-io/generic/go-ethereum/v1.10.26-statediff-4.2.2-alpha/geth-linux-amd64 && \
 	mv geth-linux-amd64 geth && \
 	chmod +x geth && \
 	mv geth /usr/local/bin

--- a/local/watcher-ts/mobymask-watcher.toml
+++ b/local/watcher-ts/mobymask-watcher.toml
@@ -9,8 +9,8 @@
   # Checkpoint interval in number of blocks.
   checkpointInterval = 2000
 
-  # IPFS API address (can be taken from the output on running the IPFS daemon).
-  # ipfsApiAddr = "/ip4/127.0.0.1/tcp/5001"
+  # Enable state creation
+  enableState = true
 
   # Boolean to filter logs by contract.
   filterLogs = true
@@ -39,7 +39,6 @@
   [upstream.ethServer]
     gqlApiEndpoint = "http://ipld-eth-server:8083/graphql"
     rpcProviderEndpoint = "http://ipld-eth-server:8082"
-    blockDelayInMilliSecs = 2000
 
   [upstream.cache]
     name = "requests"
@@ -51,3 +50,6 @@
   maxCompletionLagInSecs = 300
   jobDelayInMilliSecs = 100
   eventsInBatch = 50
+  blockDelayInMilliSecs = 2000
+  prefetchBlocksInMem = true
+  prefetchBlockCount = 10

--- a/local/watcher.env.sample
+++ b/local/watcher.env.sample
@@ -1,0 +1,4 @@
+POSTGRES_USER=vdbm
+POSTGRES_MULTIPLE_DATABASES=mobymask-watcher,mobymask-watcher-job-queue
+POSTGRES_EXTENSION=mobymask-watcher-job-queue:pgcrypto
+POSTGRES_PASSWORD=password

--- a/mainnet-watcher-only/README.md
+++ b/mainnet-watcher-only/README.md
@@ -2,6 +2,12 @@
 
 ## Setup
 
+* Create a `watcher.env` file from [watcher.env.sample](./watcher.env.sample) with updated DB credentials:
+
+  ```
+  cp watcher.env.sample watcher.env
+  ```
+
 * Update the `upstream.ethServer` endpoints in [mobymask-watcher config file](../common/watcher-ts/mobymask-watcher.toml) to point to an already deployed `ipld-eth-server`.
 
   ```toml

--- a/mainnet-watcher-only/docker-compose.yml
+++ b/mainnet-watcher-only/docker-compose.yml
@@ -27,9 +27,11 @@ services:
     depends_on:
       watcher-db:
         condition: service_healthy
+      mobymask-watcher-job-runner:
+        condition: service_healthy
     build:
       context: ../common/watcher-ts
-    command: ["sh", "-c", "yarn server"]
+    command: ["node", "--enable-source-maps", "dist/server.js"]
     volumes:
       - ../common/watcher-ts/mobymask-watcher.toml:/app/packages/mobymask-watcher/environments/local.toml
     ports:
@@ -45,17 +47,21 @@ services:
   mobymask-watcher-job-runner:
     restart: unless-stopped
     depends_on:
-      mobymask-watcher-server:
-        condition: service_healthy
       watcher-db:
         condition: service_healthy
     build:
       context: ../common/watcher-ts
-    command: ["sh", "-c", "yarn job-runner"]
+    command: ["node", "--enable-source-maps", "dist/job-runner.js"]
     volumes:
       - ../common/watcher-ts/mobymask-watcher.toml:/app/packages/mobymask-watcher/environments/local.toml
     ports:
       - "0.0.0.0:9000:9000"
+    healthcheck:
+      test: ["CMD", "nc", "-v", "localhost", "9000"]
+      interval: 20s
+      timeout: 5s
+      retries: 15
+      start_period: 5s
 
 volumes:
   indexer_db_data:

--- a/mainnet-watcher-only/docker-compose.yml
+++ b/mainnet-watcher-only/docker-compose.yml
@@ -5,11 +5,7 @@ services:
   watcher-db:
     restart: unless-stopped
     image: postgres:14-alpine
-    environment:
-      - POSTGRES_USER=vdbm
-      - POSTGRES_MULTIPLE_DATABASES=mobymask-watcher,mobymask-watcher-job-queue
-      - POSTGRES_EXTENSION=mobymask-watcher-job-queue:pgcrypto
-      - POSTGRES_PASSWORD=password
+    env_file: ./watcher.env
     volumes:
       - ../common/initdb.d/multiple-postgressql-databases.sh:/docker-entrypoint-initdb.d/multiple-postgressql-databases.sh
       - watcher_db_data:/var/lib/postgresql/data

--- a/mainnet-watcher-only/watcher.env.sample
+++ b/mainnet-watcher-only/watcher.env.sample
@@ -1,0 +1,4 @@
+POSTGRES_USER=vdbm
+POSTGRES_MULTIPLE_DATABASES=mobymask-watcher,mobymask-watcher-job-queue
+POSTGRES_EXTENSION=mobymask-watcher-job-queue:pgcrypto
+POSTGRES_PASSWORD=password

--- a/mainnet/README.md
+++ b/mainnet/README.md
@@ -14,6 +14,12 @@
   ./makejwt.sh
   ```
 
+* Create a `watcher.env` file from [watcher.env.sample](./watcher.env.sample) with updated DB credentials:
+
+  ```
+  cp watcher.env.sample watcher.env
+  ```
+
 ## Run
 
 * Start `ipld-eth-db` and `watcher-db` services:

--- a/mainnet/docker-compose.yml
+++ b/mainnet/docker-compose.yml
@@ -123,11 +123,7 @@ services:
   watcher-db:
     restart: unless-stopped
     image: postgres:14-alpine
-    environment:
-      - POSTGRES_USER=vdbm
-      - POSTGRES_MULTIPLE_DATABASES=mobymask-watcher,mobymask-watcher-job-queue
-      - POSTGRES_EXTENSION=mobymask-watcher-job-queue:pgcrypto
-      - POSTGRES_PASSWORD=password
+    env_file: ./watcher.env
     volumes:
       - ../common/initdb.d/multiple-postgressql-databases.sh:/docker-entrypoint-initdb.d/multiple-postgressql-databases.sh
       - watcher_db_data:/var/lib/postgresql/data

--- a/mainnet/docker-compose.yml
+++ b/mainnet/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     depends_on:
       ipld-eth-db:
         condition: service_healthy
-    image: git.vdb.to/cerc-io/ipld-eth-db/ipld-eth-db:v4.2.1-alpha-unstable
+    image: git.vdb.to/cerc-io/ipld-eth-db/ipld-eth-db:v4.2.3-alpha
     environment:
       DATABASE_USER: "vdbm"
       DATABASE_NAME: "indexer"
@@ -77,7 +77,7 @@ services:
     restart: unless-stopped
     depends_on:
       - migrations
-    image: git.vdb.to/cerc-io/ipld-eth-server/ipld-eth-server:v4.2.0-alpha
+    image: git.vdb.to/cerc-io/ipld-eth-server/ipld-eth-server:v4.2.3-alpha
     environment:
       VDB_COMMAND: "serve"
       ETH_SERVER_HTTPPATH: 0.0.0.0:8082
@@ -151,9 +151,11 @@ services:
         condition: service_healthy
       watcher-db:
         condition: service_healthy
+      mobymask-watcher-job-runner:
+        condition: service_healthy
     build:
       context: ../common/watcher-ts
-    command: ["sh", "-c", "yarn server"]
+    command: ["node", "--enable-source-maps", "dist/server.js"]
     volumes:
       - ../common/watcher-ts/mobymask-watcher.toml:/app/packages/mobymask-watcher/environments/local.toml
     ports:
@@ -173,17 +175,21 @@ services:
     depends_on:
       ipld-eth-server:
         condition: service_healthy
-      mobymask-watcher-server:
-        condition: service_healthy
       watcher-db:
         condition: service_healthy
     build:
       context: ../common/watcher-ts
-    command: ["sh", "-c", "yarn job-runner"]
+    command: ["node", "--enable-source-maps", "dist/job-runner.js"]
     volumes:
       - ../common/watcher-ts/mobymask-watcher.toml:/app/packages/mobymask-watcher/environments/local.toml
     ports:
       - "0.0.0.0:9000:9000"
+    healthcheck:
+      test: ["CMD", "nc", "-v", "localhost", "9000"]
+      interval: 20s
+      timeout: 5s
+      retries: 15
+      start_period: 5s
 
 volumes:
   indexer_db_data:

--- a/mainnet/geth/Dockerfile
+++ b/mainnet/geth/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=linux/amd64 alpine
 
 WORKDIR /app
 
-RUN wget https://git.vdb.to/api/packages/cerc-io/generic/go-ethereum/v1.10.25-statediff-4.2.1-alpha/geth-linux-amd64 && \
+RUN wget https://git.vdb.to/api/packages/cerc-io/generic/go-ethereum/v1.10.26-statediff-4.2.2-alpha/geth-linux-amd64 && \
 	mv geth-linux-amd64 geth && \
 	chmod +x geth && \
 	mv geth /usr/local/bin

--- a/mainnet/watcher.env.sample
+++ b/mainnet/watcher.env.sample
@@ -1,0 +1,4 @@
+POSTGRES_USER=vdbm
+POSTGRES_MULTIPLE_DATABASES=mobymask-watcher,mobymask-watcher-job-queue
+POSTGRES_EXTENSION=mobymask-watcher-job-queue:pgcrypto
+POSTGRES_PASSWORD=password


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/127

Upgrades:

- Core:
  - `ipld-eth-db` to `v4.2.3-alpha`
  - `cerc-io/geth` to `v1.10.26-statediff-4.2.2-alpha`
  - `ipld-eth-server` to `v4.2.3-alpha`
  - `eth-statediff-fill-service` to `v4.0.7-alpha`
- Watcher:
  - `watcher-ts` to `v0.2.17`

Changes:
- Update watcher config
- Use `node` to run watcher commands to allow for graceful shutdown
- Run watcher `job-runner` before `server`
- Take watcher database credentials from an env file